### PR TITLE
exportStream was broken for 'buffer' format

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -326,7 +326,7 @@ function exportStream(stream, format) {
 		case 'base64':
 			return encode64(stream);
 		case 'buffer':
-			return new Buffer(wav);
+			return new Buffer(stream);
 		case 'data-url':
 		case 'data-uri':
 		case 'dataurl':


### PR DESCRIPTION
Hey there.

Was using your package and saw there was an error in the exportStream function. It used the variable "wav" but only "stream" was available. 

Cheers, Tim.